### PR TITLE
Improve startup with lazy imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
 import sys
 from PySide6.QtWidgets import QApplication
-from module.main_window import MainWindow
 
 def main():
     filepath = sys.argv[1] if len(sys.argv) > 1 else None
     app = QApplication(sys.argv)
+    from module.main_window import MainWindow
     win = MainWindow(filepath)
     win.show()
     sys.exit(app.exec())

--- a/module/main_window.py
+++ b/module/main_window.py
@@ -2,7 +2,6 @@ import os
 import markdown
 from PySide6.QtWidgets import QMainWindow, QTextEdit, QSplitter, QFileDialog
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtGui import QAction, QIcon
 
 
@@ -30,6 +29,7 @@ class MainWindow(QMainWindow):
         self._create_menu()
         splitter = QSplitter(Qt.Horizontal)
         self.editor = QTextEdit()
+        from PySide6.QtWebEngineWidgets import QWebEngineView
         self.preview = QWebEngineView()
         splitter.addWidget(self.editor)
         splitter.addWidget(self.preview)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PySide6>=6.0
 markdown>=3.0
 pyinstaller>=5.0
-Pillow>=9.0


### PR DESCRIPTION
## Summary
- avoid importing `module.main_window` until after QApplication creation
- lazily import `QWebEngineView` in `MainWindow`
- remove unused Pillow dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687444c91fc483269f931964579e3fd2